### PR TITLE
fix: Vercelビルドエラー修正 + 初回スクレイプ体験改善

### DIFF
--- a/app/ai-heart/page.js
+++ b/app/ai-heart/page.js
@@ -17,13 +17,12 @@ export default function AIHeartPage() {
                 if (!res.ok) throw new Error('AI Heart採点データの取得に失敗しました。');
                 return res.json();
             })
-            .then(data => {
-                const formattedHistory = data.map(item => ({
+            .then(({ history }) => {
+                setHistory(history.map(item => ({
                     ...item,
                     date: new Date(item.date),
                     score: Number(item.score) || 0,
-                }));
-                setHistory(formattedHistory);
+                })));
                 setLoading(false);
             })
             .catch(err => { setError(err.message); setLoading(false); });

--- a/app/ai/page.js
+++ b/app/ai/page.js
@@ -17,15 +17,12 @@ export default function HomePage() {
         if (!res.ok) throw new Error('データベースからのデータ取得に失敗しました。');
         return res.json();
       })
-      .then(data => {
-        // ★★★ 「一採点一表示」に戻すため、集計ロジックは不要 ★★★
-        const formattedHistory = data.map(item => ({
+      .then(({ history }) => {
+        setHistory(history.map(item => ({
           ...item,
           date: new Date(item.date),
-          // score が null や undefined でも 0 として扱う
           score: Number(item.score) || 0,
-        }));
-        setHistory(formattedHistory);
+        })));
         setLoading(false);
       })
       .catch(err => { setError(err.message); setLoading(false); });

--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -1,6 +1,8 @@
 import _NextAuth from 'next-auth';
 import { authOptions } from '../../../../lib/auth.js';
 
+export const dynamic = 'force-dynamic';
+
 // next-auth は CJS モジュールのため ESM インポート時に二重ラップされる
 const NextAuth = _NextAuth?.default ?? _NextAuth;
 

--- a/app/api/songs/ai-heart/route.js
+++ b/app/api/songs/ai-heart/route.js
@@ -10,11 +10,17 @@ export async function GET() {
   }
 
   try {
-    const history = await prisma.songHistory.findMany({
-      where: { userId: session.user.id, scoringType: 'ai-heart' },
-      orderBy: { date: 'desc' },
-    });
-    return NextResponse.json(history);
+    const [history, user] = await Promise.all([
+      prisma.songHistory.findMany({
+        where: { userId: session.user.id, scoringType: 'ai-heart' },
+        orderBy: { date: 'desc' },
+      }),
+      prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { lastScrapedAt: true },
+      }),
+    ]);
+    return NextResponse.json({ history, scraped: !!user?.lastScrapedAt });
   } catch (error) {
     console.error('AI Heart採点データの取得エラー:', error);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });

--- a/app/api/songs/ai/route.js
+++ b/app/api/songs/ai/route.js
@@ -10,11 +10,17 @@ export async function GET() {
   }
 
   try {
-    const history = await prisma.songHistory.findMany({
-      where: { userId: session.user.id, scoringType: 'ai' },
-      orderBy: { date: 'desc' },
-    });
-    return NextResponse.json(history);
+    const [history, user] = await Promise.all([
+      prisma.songHistory.findMany({
+        where: { userId: session.user.id, scoringType: 'ai' },
+        orderBy: { date: 'desc' },
+      }),
+      prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { lastScrapedAt: true },
+      }),
+    ]);
+    return NextResponse.json({ history, scraped: !!user?.lastScrapedAt });
   } catch (error) {
     console.error('AI採点データの取得エラー:', error);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });

--- a/app/layout.js
+++ b/app/layout.js
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import Sidebar from '../components/Sidebar';
 import styles from './Layout.module.css';
 
-const AUTH_PATHS = ['/login'];
+const AUTH_PATHS = ['/login', '/loading'];
 
 export default function RootLayout({ children }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);

--- a/app/loading/page.js
+++ b/app/loading/page.js
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LoadingPage() {
+  const router = useRouter();
+  const pollRef = useRef(null);
+  const pollCount = useRef(0);
+  const MAX_POLL = 40; // 最大40回 × 3秒 = 120秒
+
+  useEffect(() => {
+    const check = async () => {
+      try {
+        const res = await fetch('/api/songs/ai');
+        if (!res.ok) { router.push('/ai'); return; }
+        const { history, scraped } = await res.json();
+        // データが1件でも入っていれば遷移（全件揃うのを待たない）
+        if (history.length > 0 || scraped) {
+          clearInterval(pollRef.current);
+          router.push('/ai');
+        }
+      } catch {
+        clearInterval(pollRef.current);
+        router.push('/ai');
+      }
+    };
+
+    // 即時チェック
+    check();
+
+    pollRef.current = setInterval(() => {
+      pollCount.current += 1;
+      if (pollCount.current >= MAX_POLL) {
+        clearInterval(pollRef.current);
+        router.push('/ai');
+        return;
+      }
+      check();
+    }, 3000);
+
+    return () => clearInterval(pollRef.current);
+  }, []);
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      gap: '1rem',
+      color: '#64748b',
+      fontFamily: 'sans-serif',
+    }}>
+      <p style={{ fontSize: '1rem' }}>初回データを取得中です。しばらくお待ちください...</p>
+      <p style={{ fontSize: '0.875rem', color: '#94a3b8' }}>完了後に自動で画面が切り替わります</p>
+    </div>
+  );
+}

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -30,8 +30,7 @@ export default function LoginPage() {
         ? result.error
         : 'IDまたはパスワードが正しくありません');
     } else {
-      router.push('/ai');
-      router.refresh();
+      router.push('/loading');
     }
   };
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -40,11 +40,16 @@ export const authOptions = {
           user = await prisma.user.create({
             data: { cdmCardNo, damLoginId: credentials.loginId },
           });
-          // 初回ログイン時にバックグラウンドでスクレイプ
+            // 初回ログイン時にバックグラウンドでスクレイプ、完了後に lastScrapedAt を更新
           Promise.allSettled([
             scrapeScoring({ userId: user.id, cdmCardNo, scoringType: 'ai' }),
             scrapeScoring({ userId: user.id, cdmCardNo, scoringType: 'ai-heart' }),
-          ]).catch(err => console.error('初回スクレイプエラー:', err));
+          ]).finally(() => {
+            prisma.user.update({
+              where: { id: user.id },
+              data: { lastScrapedAt: new Date() },
+            }).catch(err => console.error('lastScrapedAt 更新エラー:', err));
+          });
         } else {
           // damLoginId が変わっていれば更新
           if (user.damLoginId !== credentials.loginId) {

--- a/middleware.js
+++ b/middleware.js
@@ -6,5 +6,5 @@ const withAuth = _withAuth?.default ?? _withAuth;
 export default withAuth;
 
 export const config = {
-  matcher: ['/', '/ai', '/ai-heart', '/song/:path*'],
+  matcher: ['/', '/ai', '/ai-heart', '/song/:path*', '/loading'],
 };


### PR DESCRIPTION
## Summary

- NextAuth ルートに `force-dynamic` を追加し Vercel ビルドエラーを修正
- 初回ログイン後に `/loading` ページでスクレイプ完了を待つ仕組みを追加
- データが1件でも入り次第 `/ai` に遷移（全件待たない）
- DAM★とも認証のみに一本化した諸々の修正

## Test plan

- [ ] Vercel でビルドが通ること
- [ ] 初回ログイン → `/loading` → データ取得後に `/ai` へ遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)